### PR TITLE
Fixed #5: .selector container clears float

### DIFF
--- a/responsive_admin/static/admin/css/admin.css
+++ b/responsive_admin/static/admin/css/admin.css
@@ -72,6 +72,8 @@ th.action-checkbox-column {
 div.selector {
 	margin-left:170px;
 	height:200px;
+	overflow: auto;
+	width: 100%;
 	clear: both;
 }
 


### PR DESCRIPTION
Used the solution from http://www.quirksmode.org/css/clearing.html to fix selectors.

Without patch:
![without](https://f.cloud.github.com/assets/94636/1191004/8bcf86e4-2444-11e3-955f-ddf597bc0a83.png)

With patch:
![with](https://f.cloud.github.com/assets/94636/1191003/8bb4a91e-2444-11e3-9323-f424f4e8d2e8.png)
